### PR TITLE
Transplant CBAlerter from CBLogger, build out testing framework and Circle support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+        
+      # run tests
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+**/.DS_Store
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+**/.DS_Store
+package-lock.json
+.circleci/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+[![CircleCI](https://circleci.com/gh/unplgtc/CBAlerter.svg?style=svg)](https://circleci.com/gh/unplgtc/CBAlerter)
+
 # CBAlerter
+
 Standardized webhook alerting object for Node applications

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  clearMocks: true,
+  coverageDirectory: "test/coverage",
+  rootDir: "test",
+  testEnvironment: "node"
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@unplgtc/cbalerter",
+  "version": "0.0.0",
+  "description": "Standardized webhook alerting object for Node applications",
+  "main": "src/CBAlerter.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unplgtc/CBAlerter.git"
+  },
+  "author": "Alex Guyot <guyot@unapologetic.io> (https://unapologetic.io)",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/unplgtc/CBAlerter/issues"
+  },
+  "homepage": "https://github.com/unplgtc/CBAlerter#readme",
+  "devDependencies": {
+    "jest": "^23.4.2"
+  },
+  "dependencies": {
+    "@unplgtc/standarderror": "0.0.1",
+    "request": "^2.87.0"
+  },
+  "directories": {
+    "test": "test"
+  }
+}

--- a/src/CBAlerter.js
+++ b/src/CBAlerter.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const request = require('request');
+const StandardError = require('@unplgtc/standarderror');
+
+const CBAlerter = {
+	alert(payload, webhookName = 'default') {
+		if (!this.webhooks[webhookName]) {
+			return StandardError.cbalerter_404;
+		}
+		return this.postToWebhook(payload, webhookName);
+	},
+
+	addWebhook(url, name = 'default') {
+		if (this.webhooks[name]) {
+			return StandardError.cbalerter_409;
+		}
+		this.webhooks[name] = {url: url};
+		return true;
+	}
+}
+
+const Internal = {
+	webhooks: {},
+
+	postToWebhook(payload, name) {
+		request.post({
+			url: this.webhooks[name].url,
+			body: payload,
+			json: true
+		}, function(err, response, body) {
+			if (!err) {
+				console.log(body);
+			} else {
+				console.error('Error: ' + response.statusCode);
+			}
+		});
+		return true;
+	}
+}
+
+StandardError.add([
+	{code: 'cbalerter_404', domain: 'CBAlerter', title: 'Not Found', message: 'A webhook with the requested name could not be found'},
+	{code: 'cbalerter_409', domain: 'CBAlerter', title: 'Conflict', message: 'A webhook with the given name already exists'}
+]);
+
+Object.setPrototypeOf(CBAlerter, Internal);
+
+module.exports = CBAlerter;

--- a/src/test.js
+++ b/src/test.js
@@ -1,0 +1,7 @@
+const CBAlerter = require('./CBAlerter');
+
+CBAlerter.addWebhook('https://hooks.slack.com/services/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');
+
+console.log(CBAlerter.alert({
+	text: 'Testing'
+}));

--- a/test/CBAlerter.test.js
+++ b/test/CBAlerter.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const CBAlerter = require('./../src/CBAlerter');
+const StandardError = require('@unplgtc/standarderror');
+const request = require('request');
+
+var url = 'some_url';
+
+var namedWebhook = 'test';
+var url2 = 'some_other_url';
+
+test('Can\'t default alert before a default webhook has been added', async() => {
+	// Setup
+	var mockedPayload = {
+		text: 'Testing'
+	};
+
+	// Execute
+	var res = CBAlerter.alert(mockedPayload);
+
+	// Test
+	expect(res).toBe(StandardError.cbalerter_404);
+});
+
+test('Can add a default webhook', async() => {
+	// Execute
+	var success = CBAlerter.addWebhook(url);
+
+	// Test
+	expect(success).toBe(true);
+});
+
+test('Can send an alert via the default webhook', async() => {
+	// Setup
+	var mockedPayload = {
+		text: 'Testing'
+	};
+	var mockedPostPayload = {
+		url: url,
+		body: mockedPayload,
+		json: true
+	};
+	request.post = jest.fn();
+
+	// Execute
+	var sent = CBAlerter.alert(mockedPayload);
+
+	// Test
+	expect(sent).toBe(true);
+	expect(request.post).toHaveBeenCalledWith(mockedPostPayload, expect.any(Function));
+});
+
+test('Can\'t add a second default webhook', async() => {
+	// Execute
+	var success = CBAlerter.addWebhook(url);
+
+	// Test
+	expect(success).toBe(StandardError.cbalerter_409);
+});
+
+test('Can add a named webhook', async() => {
+	// Execute
+	var success = CBAlerter.addWebhook(url2, namedWebhook);
+
+	// Test
+	expect(success).toBe(true);
+});
+
+test('Can send an alert via a named webhook', async() => {
+	// Setup
+	var mockedPayload = {
+		text: 'Testing'
+	};
+	var mockedPostPayload = {
+		url: url2,
+		body: mockedPayload,
+		json: true
+	};
+	request.post = jest.fn();
+
+	// Execute
+	var sent = CBAlerter.alert(mockedPayload, namedWebhook);
+
+	// Test
+	expect(sent).toBe(true);
+	expect(request.post).toHaveBeenCalledWith(mockedPostPayload, expect.any(Function));
+});
+
+test('Can\'t add a named webhook with an existing name', async() => {
+	// Execute
+	var success = CBAlerter.addWebhook(url2, namedWebhook);
+
+	// Test
+	expect(success).toBe(StandardError.cbalerter_409);
+});


### PR DESCRIPTION
CBAlerter will now run independently of CBLogger, CBLogger will be updated to enable expanding its prototype with a passed in object, which will be how services are expected to set up alerter.