### PR TITLE
Send requests via HttpRequest objects instead of request calls, return Promises from alert(), version to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/cbalerter",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Standardized webhook alerting object for Node applications",
   "main": "src/CBAlerter.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/cbalerter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Standardized webhook alerting object for Node applications",
   "main": "src/CBAlerter.js",
   "scripts": {
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@unplgtc/standard-error": "0.0.1",
-    "request": "^2.87.0"
+    "@unplgtc/http-request": "0.0.0",
+    "@unplgtc/standard-promise": "0.0.2"
   },
   "directories": {
     "test": "test"

--- a/src/CBAlerter.js
+++ b/src/CBAlerter.js
@@ -1,15 +1,16 @@
 'use strict';
 
-const request = require('request');
+const _ = require('@unplgtc/standard-promise');
+const HttpRequest = require('@unplgtc/http-request');
 const StandardError = require('@unplgtc/standard-error');
 
 const CBAlerter = {
 	alert(level, key, data, options, err) {
 		var webhook = options.webhook ? options.webhook : 'default';
 		if (!this.webhooks[webhook]) {
-			return StandardError.CBAlerter_404;
+			return _(Promise.reject(StandardError.CBAlerter_404));
 		}
-		return this.postToWebhook(webhook, level, key, data, options, err);
+		return _(this.postToWebhook(webhook, level, key, data, options, err));
 	},
 
 	addWebhook(builder, name = 'default') {
@@ -28,17 +29,9 @@ const Internal = {
 	webhooks: {},
 
 	postToWebhook(webhook, level, key, data, options, err) {
-		request.post(
-			this.webhooks[webhook](level, key, data, options, err),
-			function(err, response, body) {
-				if (!err) {
-					console.log(body);
-				} else {
-					console.error('Error: ' + response.statusCode);
-				}
-			}
-		);
-		return true;
+		return HttpRequest.create()
+			.build(this.webhooks[webhook](level, key, data, options, err))
+			.post()
 	}
 }
 

--- a/src/test.js
+++ b/src/test.js
@@ -1,7 +1,0 @@
-const CBAlerter = require('./CBAlerter');
-
-CBAlerter.addWebhook('https://hooks.slack.com/services/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');
-
-console.log(CBAlerter.alert({
-	text: 'Testing'
-}));


### PR DESCRIPTION
- Send requests via `HttpRequest` objects instead of `request` calls
- Return Promises from the alert() function instead of just true or StandardErrors
- Bump version to 0.0.4

Resolves #3 