### PR TITLE
Remove StandardPromise dependency, bump version to 0.1.2, HttpRequest dep to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/cbalerter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Standardized webhook alerting object for Node applications",
   "main": "src/CBAlerter.js",
   "scripts": {
@@ -21,8 +21,7 @@
   },
   "dependencies": {
     "@unplgtc/standard-error": "0.1.0",
-    "@unplgtc/http-request": "0.1.1",
-    "@unplgtc/standard-promise": "0.2.0"
+    "@unplgtc/http-request": "0.2.1"
   },
   "directories": {
     "test": "test"

--- a/src/CBAlerter.js
+++ b/src/CBAlerter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('@unplgtc/standard-promise');
 const HttpRequest = require('@unplgtc/http-request');
 const StandardError = require('@unplgtc/standard-error');
 
@@ -8,9 +7,9 @@ const CBAlerter = {
 	alert(level, key, data, options, err) {
 		var webhook = options.webhook ? options.webhook : 'default';
 		if (!this.webhooks[webhook]) {
-			return _(Promise.reject(StandardError.CBAlerter_404));
+			return Promise.reject(StandardError.CBAlerter_404);
 		}
-		return _(this.postToWebhook(webhook, level, key, data, options, err));
+		return this.postToWebhook(webhook, level, key, data, options, err);
 	},
 
 	addWebhook(builder, name = 'default') {

--- a/test/CBAlerter.test.js
+++ b/test/CBAlerter.test.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const _ = require('@unplgtc/standard-promise');
 const CBAlerter = require('./../src/CBAlerter');
 const StandardError = require('@unplgtc/standard-error');
 const HttpRequest = require('@unplgtc/http-request');
 
 HttpRequest.build = jest.fn(() => HttpRequest);
-HttpRequest.post = jest.fn(() => _(Promise.resolve()));
+HttpRequest.post = jest.fn(() => Promise.resolve());
 
 var builder = function(level, key, data, options, err) {
 	return {
@@ -34,10 +33,12 @@ var moreMockedArgs = ['ERROR', 'another_test_key', {text: 'testing again'}, {ale
 
 test('Can\'t trigger a default alert before a default webhook has been added', async() => {
 	// Execute
-	var res = await CBAlerter.alert(...mockedArgs);
+	var resErr;
+	var res = await CBAlerter.alert(...mockedArgs)
+		.catch((err) => { resErr = err; });
 
 	// Test
-	expect(res.err).toBe(StandardError.CBAlerter_404);
+	expect(resErr).toBe(StandardError.CBAlerter_404);
 });
 
 test('Can add a default webhook', async() => {
@@ -50,10 +51,12 @@ test('Can add a default webhook', async() => {
 
 test('Can send an alert via the default webhook', async() => {
 	// Execute
-	var sent = await CBAlerter.alert(...mockedArgs);
+	var resErr;
+	var res = await CBAlerter.alert(...mockedArgs)
+		.catch((err) => { resErr = err; });
 
 	// Test
-	expect(sent.err).toBe(undefined);
+	expect(resErr).toBe(undefined);
 	expect(HttpRequest.build).toHaveBeenCalledWith(builder(...mockedArgs));
 	expect(HttpRequest.post).toHaveBeenCalled();
 });
@@ -76,10 +79,12 @@ test('Can add a named webhook', async() => {
 
 test('Can send an alert via a named webhook', async() => {
 	// Execute
-	var sent = await CBAlerter.alert(...moreMockedArgs);
+	var resErr;
+	var res = await CBAlerter.alert(...moreMockedArgs)
+		.catch((err) => { resErr = err; });
 
 	// Test
-	expect(sent.err).toBe(undefined);
+	expect(resErr).toBe(undefined);
 	expect(HttpRequest.build).toHaveBeenCalledWith(anotherBuilder(...moreMockedArgs));
 	expect(HttpRequest.post).toHaveBeenCalled();
 });


### PR DESCRIPTION
Removing StandardPromise makes this package more versatile, plus CBLogger implements it anyway so adding it here was unnecessary. 