### PR TITLE
Allow builder functions to have any number of arguments

### DIFF
--- a/src/CBAlerter.js
+++ b/src/CBAlerter.js
@@ -16,7 +16,7 @@ const CBAlerter = {
 		if (this.webhooks[name]) {
 			return StandardError.CBAlerter_409();
 		}
-		if (typeof builder != 'function' || builder.length < 5) {
+		if (typeof builder != 'function') {
 			return StandardError.CBAlerter_400();
 		}
 		this.webhooks[name] = builder;


### PR DESCRIPTION
Since JavaScript functions can be called with extra or too few arguments without causing a runtime error, this PR removes the strict lower bound limit on the number of arguments required for the builder function.

## Changes

- Removed minimum argument length requirement for webhook builder functions