### PR TITLE
Upgrade to use ES module imports, upgrade deps, minor fixes and improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: cimg/node:16.13.0
 
     working_directory: ~/repo
 
@@ -22,6 +22,6 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       # run tests
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Extending an instance of CBLogger with a CBAlerter object will allow alert paylo
 Import CBAlerter into your Node project:
 
 ```js
-const CBAlerter = require('@unplgtc/cbalerter');
+import CBAlerter from '@unplgtc/cbalerter';
 ```
 
 CBAlerter needs you to configure a webhook before it will be able to kick off requests for you. This can be done with the `addWebhook` function, which takes two arguments: `builder` and `name`. `name` is an optional argument, and if you don't pass one in then the value will be set as `'default'` (but you should never need to worry about that). The `builder` argument should be a function which takes five arguments (`level`, `key`, `data`, `options`, and `err`) and returns a payload that will be sent to your webhook.
@@ -24,13 +24,14 @@ function builder(level, key, data, options, err) {
 	return {
 		url: 'https://example.com/webhook',
 		headers: {
-			Authorization: `Bearer ${process.env.secretToken`}
+			Authorization: `Bearer ${process.env.secretToken}`
 		},
 		body: {
 			text: `${level}: ${key}`,
 			data: data,
 			err: err
-		}
+		},
+		options
 	}
 }
 
@@ -40,39 +41,52 @@ CBAlerter.addWebhook(builder);
 The above code would create a new default webhook using the `builder` function. From then on any time you call `CBAlerter.alert([...])`, the arguments from that call will be passed through to `builder` to generate a payload. That payload will then be sent as a POST request.
 
 ```js
-CBAlerter.alert('ERROR', 'foo', {bar: baz}, undefined, new Error());
+CBAlerter.alert('ERROR', 'foo', { bar: baz }, {}, new Error());
 ```
 
-The above call would be passed to `builder` to generate a payload, then that payload would be POSTed to "https://example.com/webhook". Your builder should always include the URL and any required headers in its payload. CBAlerter is just going to send whatever payload the builder returns via POST.
-
-CBAlerter's `alert()` function uses [request-promise-native](https://github.com/request/request-promise-native) to POST requests. It returns the Promise that request-promise-native generates, which you can then unwrap to access the success or failure status of your alert.
+As long as you're using the default (unnamed) webhook, you don't actually need to pass in an `options` argument. If an `Error` is sent in that argument position, CBAlerter will figure this out and apply your arguments correctly. In other words, the above code is equivalent to this:
 
 ```js
-var res = await CBAlerter.alert('ERROR', 'foo', {bar: baz}, undefined, new Error())
-	.catch((err) => console.error('Error!', err));
+CBAlerter.alert('ERROR', 'foo', { bar: baz }, new Error());
+```
 
-if (res.statusCode === 200) {
+The `err` argument is also optional, so if you don't have an error that you need to alert about, and you want to use the default webhook, you can trigger an alert with even fewer arguments:
+
+```js
+CBAlerter.alert('INFO', 'foo', { bar: baz });
+```
+
+The above calls would be passed to your `builder` function to generate payloads, then those payloads would be POSTed to "https://example.com/webhook". Your builder should always include the URL and any required headers in its payload. CBAlerter is just going to send whatever payload the builder returns via POST.
+
+CBAlerter's `alert()` function uses Unapologetic's [HttpRequest](https://github.com/unplgtc/HttpRequest) package to POST requests. See that package for info on what data is returned for each of your requests, and what options you can use when configuring payloads in your `builder`.
+
+```js
+let resErr;
+const res = await CBAlerter.alert('ERROR', 'foo', { bar: baz }, new Error())
+	.catch(err => resErr = err);
+
+if (!resErr) {
 	console.log('Success!');
 }
 ```
 
-CBAlerter supports more than one webhook configurations at a time. Just add further webhooks with non-null `name` arguments to configure options beyond `'default'`.
+CBAlerter supports more than one webhook configuration at a time. Just add further webhooks with non-null `name` arguments to configure options beyond the `'default'` webhook.
 
 ```js
-CBAlerter.addWebhook(builder, 'another_webhook');
+CBAlerter.addWebhook('another_webhook', builder);
 ```
 
-To activate a named webhook, just pass the name into your calls to `alert()` via a `webhook` parameter in the `options` argument.
+To activate a named webhook, just pass the name into your calls to `alert()` via the `webhook` parameter in the `options` argument:
 
 ```js
-CBAlerter.alert('ERROR', 'foo', {bar: baz}, {webhook: 'another_webhook'}, new Error());
+CBAlerter.alert('ERROR', 'foo', { bar: baz }, { webhook: 'another_webhook' }, new Error());
 ```
 
 To use CBAlerter with CBLogger, import CBAlerter as usual and configure webhooks just as described above. Once your alerter is set up, pass it to `CBLogger.extend()` and you'll be ready to go.
 
 ```js
-const CBAlerter = require('@unplgtc/cbalerter');
-const CBLogger = require('@unplgtc/cblogger');
+import CBAlerter from '@unplgtc/cbalerter';
+import CBLogger from '@unplgtc/cblogger';
 
 function builder(level, key, data, options, err) { ... }
 
@@ -80,7 +94,13 @@ CBAlerter.addWebhook(builder);
 
 CBLogger.extend(CBAlerter);
 
-CBLogger.error('ERROR', 'foo', {bar: baz}, {alert: true}, new Error());
+CBLogger.error('ERROR', 'foo', { bar: baz }, { alert: true }, new Error());
 ```
 
-The above code will output a log message in CBLogger's standardized format, then POST an alert with the same data using CBAlerter's configured `builder` function to generate the payload.
+The above code will output a log message in CBLogger's standardized format, then POST an alert with the same data using the `builder` function that you configured CBAlerter with to generate the payload.
+
+CBLogger's `options` argument is passed directly through to CBAlerter, so you can trigger named webhooks intuitively:
+
+```js
+CBLogger.error('ERROR', 'foo', { bar: baz }, { alert: true, webhook: 'another_webhook' }, new Error());
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
-module.exports = {
+export default {
   clearMocks: true,
   coverageDirectory: "test/coverage",
   rootDir: "test",
-  testEnvironment: "node"
+  testEnvironment: "node",
+  transform: {}
 };

--- a/package.json
+++ b/package.json
@@ -1,27 +1,31 @@
 {
   "name": "@unplgtc/cbalerter",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Webhook alerting object for Node applications and CBLogger",
-  "main": "src/CBAlerter.js",
+  "type": "module",
+  "exports": "./src/CBAlerter.js",
+  "engines": {
+    "node": ">=14.13.1 || >=16.0.0"
+  },
   "scripts": {
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/unplgtc/CBAlerter.git"
   },
-  "author": "Alex Guyot <guyot@unapologetic.io> (https://unapologetic.io)",
+  "author": "Alex Guyot <alex@unapologetic.io> (https://unapologetic.io)",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/unplgtc/CBAlerter/issues"
   },
   "homepage": "https://github.com/unplgtc/CBAlerter#readme",
   "devDependencies": {
-    "jest": "^23.4.2"
+    "jest": "^27.3.1"
   },
   "dependencies": {
-    "@unplgtc/standard-error": "1.0.0",
-    "@unplgtc/http-request": "1.1.1"
+    "@unplgtc/http-request": "4.0.1",
+    "@unplgtc/standard-error": "3.0.1"
   },
   "directories": {
     "test": "test"

--- a/test/CBAlerter.test.js
+++ b/test/CBAlerter.test.js
@@ -1,49 +1,57 @@
-'use strict';
+import CBAlerter from './../src/CBAlerter.js';
+import HttpRequest from '@unplgtc/http-request';
+import { jest } from '@jest/globals';
 
-const CBAlerter = require('./../src/CBAlerter');
-const StandardError = require('@unplgtc/standard-error');
-const HttpRequest = require('@unplgtc/http-request');
+import Errors from '@unplgtc/standard-error';
+const { AlreadyExistsError, NotFoundError, HttpError } = Errors;
 
 HttpRequest.build = jest.fn(() => HttpRequest);
 HttpRequest.post = jest.fn(() => Promise.resolve());
 
-var builder = function(level, key, data, options, err) {
+const builder = function(level, key, data, options, err) {
 	return {
 		url: 'some_url',
 		body: {
 			key: key,
 			data: data
-		},
-		json: true
+		}
 	}
 }
-var anotherBuilder = function(level, key, data, options, err) {
+
+const anotherBuilder = function(level, key, data, options, err) {
 	return {
 		url: 'some_other_url',
 		body: {
 			key: key,
 			data: data
-		},
-		json: true
+		}
 	}
 }
-var webhookName = 'some_webhook_name';
-var mockedArgs = ['DEBUG', 'test_key', {text: 'testing'}, {alert: true}];
-var moreMockedArgs = ['ERROR', 'another_test_key', {text: 'testing again'}, {alert: true, webhook: webhookName}, StandardError.http_500()];
+
+const webhookName = 'some_webhook_name',
+      mockedArgs = [ 'DEBUG', 'test_key', { text: 'testing' }, {}],
+      http500Error = new HttpError(500),
+      moreMockedArgs = [ 'ERROR', 'another_test_key', {text: 'testing again' }, { webhook: webhookName }, http500Error ],
+      noOptionsArgs = [ 'DEBUG', 'test_key', { text: 'testing' } ],
+      errorAsOptionsArgs = [ 'DEBUG', 'test_key', { text: 'testing' }, http500Error ];
 
 test('Can\'t trigger a default alert before a default webhook has been added', async() => {
 	// Execute
-	var resErr;
-	var res = await CBAlerter.alert(...mockedArgs)
-		.catch((err) => { resErr = err; });
+	let resErr;
+	try {
+		const res = await CBAlerter.alert(...mockedArgs)
+
+	} catch (err) {
+		resErr = err;
+	}
 
 	// Test
-	expect(resErr).toEqual(StandardError.CBAlerter_404());
+	expect(resErr instanceof NotFoundError).toBe(true);
 });
 
 test('Can add a default webhook', async() => {
 	// Execute
-	var success = CBAlerter.addWebhook(builder);
+	const success = CBAlerter.addWebhook(builder);
 
 	// Test
 	expect(success).toBe(true);
@@ -51,8 +59,8 @@ test('Can add a default webhook', async() => {
 
 test('Can send an alert via the default webhook', async() => {
 	// Execute
-	var resErr;
-	var res = await CBAlerter.alert(...mockedArgs)
+	let resErr;
+	const res = await CBAlerter.alert(...mockedArgs)
 		.catch((err) => { resErr = err; });
 
 	// Test
@@ -63,15 +71,21 @@ test('Can send an alert via the default webhook', async() => {
 
 test('Can\'t add a second default webhook', async() => {
 	// Execute
-	var success = CBAlerter.addWebhook(anotherBuilder);
+	let resErr;
+	try {
+		const success = CBAlerter.addWebhook(anotherBuilder);
+
+	} catch (err) {
+		resErr = err;
+	}
 
 	// Test
-	expect(success).toEqual(StandardError.CBAlerter_409());
+	expect(resErr instanceof AlreadyExistsError).toBe(true);
 });
 
 test('Can add a named webhook', async() => {
 	// Execute
-	var success = CBAlerter.addWebhook(anotherBuilder, webhookName);
+	const success = CBAlerter.addWebhook(webhookName, anotherBuilder);
 
 	// Test
 	expect(success).toBe(true);
@@ -79,8 +93,8 @@ test('Can add a named webhook', async() => {
 
 test('Can send an alert via a named webhook', async() => {
 	// Execute
-	var resErr;
-	var res = await CBAlerter.alert(...moreMockedArgs)
+	let resErr;
+	const res = await CBAlerter.alert(...moreMockedArgs)
 		.catch((err) => { resErr = err; });
 
 	// Test
@@ -91,8 +105,44 @@ test('Can send an alert via a named webhook', async() => {
 
 test('Can\'t add a named webhook with an existing name', async() => {
 	// Execute
-	var success = CBAlerter.addWebhook(builder, webhookName);
+	let resErr;
+	try {
+		const success = CBAlerter.addWebhook(webhookName, builder);
+
+	} catch (err) {
+		resErr = err;
+	}
 
 	// Test
-	expect(success).toEqual(StandardError.CBAlerter_409());
+	expect(resErr instanceof AlreadyExistsError).toBe(true);
+});
+
+test('Can send an alert with no options', async() => {
+	// Execute
+	let resErr;
+	const res = await CBAlerter.alert(...noOptionsArgs)
+		.catch((err) => { resErr = err; });
+
+	// Test
+	expect(resErr).toBe(undefined);
+	expect(HttpRequest.build).toHaveBeenCalledWith(builder(...[ ...noOptionsArgs, {} ]));
+	expect(HttpRequest.post).toHaveBeenCalled();
+});
+
+test('Can send an alert with error as options arg', async() => {
+	// Setup
+	const expectedArgs = errorAsOptionsArgs;
+	expectedArgs.pop(); // Remove http500Error
+	expectedArgs.push({}); // Add the default options arg that CBAlerter will create
+	expectedArgs.push(http500Error); // Add back http500Error
+
+	// Execute
+	let resErr;
+	const res = await CBAlerter.alert(...errorAsOptionsArgs)
+		.catch((err) => { resErr = err; });
+
+	// Test
+	expect(resErr).toBe(undefined);
+	expect(HttpRequest.build).toHaveBeenCalledWith(builder(...expectedArgs));
+	expect(HttpRequest.post).toHaveBeenCalled();
 });


### PR DESCRIPTION
- Upgrade to use ES module imports
- Upgrade to HttpRequest v4
- Upgrade to StandardError v3
- Swap position of `name` and `builder` arguments in `addWebhook()` function
- Make `options` argument optional