### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/cbalerter",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Webhook alerting object for Node applications and CBLogger",
   "type": "module",
   "exports": "./src/CBAlerter.js",


### PR DESCRIPTION
Changelog:
- Upgrade to use ES module imports
- Upgrade to HttpRequest v4
- Upgrade to StandardError v3
- Swap position of `name` and `builder` arguments in `addWebhook()` function
- Make `options` argument optional